### PR TITLE
Add Compile-Time Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Ignore compiled binaries
 /target
+
+# Ignore configuration module
+# Use the one in `config/`
+/src/config.rs

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+//! Build script for SUS
+//!
+//! We need to copy over the configuration module. We put it with all the other
+//! configuration files for ease of use. However, we need it to be in `src/` to
+//! actually use it in our code.
+
+/// The original configuration file's path
+const ORG: &str = "config/build.rs";
+/// The path the configuration file should be copied to
+const NEW: &str = "src/config.rs";
+
+fn main() -> Result<(), std::io::Error> {
+    // Only need to do this if the configuration has changed
+    // Overwrite any changes to the copy in `src/` as well
+    println!("cargo:rerun-if-changed={}", ORG);
+    println!("cargo:rerun-if-changed={}", NEW);
+
+    // Copy it over
+    std::fs::copy(ORG, NEW)?;
+    // Done
+    Ok(())
+}

--- a/config/build.rs
+++ b/config/build.rs
@@ -1,0 +1,10 @@
+//! Configuration variables for SUS
+//!
+//! This file contains some configuration variables for the SUS application. It
+//! defines constants that are to be compiled into the final binary.
+//!
+//! Make sure to edit this file in `config/build.rs`. This file is copied to the
+//! `src/` directory as part of the build process. Any changes made there will
+//! be ignored by `cargo build`.
+
+mod config;


### PR DESCRIPTION
Added a method of configuring the binary at compile-time. It uses the `config/build.rs` file and copies that into the `src/` directory so that code can access it.