### PR TITLE
Mitigate Timing Attack

### DIFF
--- a/src/bin/sus-kernel/request.rs
+++ b/src/bin/sus-kernel/request.rs
@@ -11,6 +11,7 @@ use crate::executable::run::RunError;
 use crate::executable::Executable;
 use crate::permission::verify::AbstractVerifier;
 use crate::permission::verify::VerifyError;
+use crate::permission::verify::VerifyResult;
 use crate::permission::Permission;
 
 use std::convert::Infallible;
@@ -60,15 +61,22 @@ impl Request {
     /// [vf]: crate::permission::verify::Verifier
     pub fn service(mut self) -> RequestResult {
         // Assert that all the verifications pass
+        // Make sure to execute all the verifiers, regardless of if they fail.
+        //  This helps us mitigate timing attacks.
         // Note the question mark to unwrap the result
-        for mut v in self.verifiers {
-            v(
-                &self.current_permissions,
-                &self.requested_permissions,
-                &self.executable,
-            )
-            .map_err(|e| RequestError::Verify { cause: e })?;
-        }
+        let verify_res = {
+            let mut res: VerifyResult = Ok(());
+            for mut v in self.verifiers {
+                res = res.and(v(
+                    &self.current_permissions,
+                    &self.requested_permissions,
+                    &self.executable,
+                ));
+            }
+            // Return
+            res
+        };
+        verify_res.map_err(|e| RequestError::Verify { cause: e })?;
         // Execute and unwrap
         (self.runner)(&self.requested_permissions, &self.executable)
             .map_err(|e| RequestError::Run { cause: e })


### PR DESCRIPTION
Originally, the code did not execute all of the verifications before returning failure. This is an opportunity for a timing attack. An attacker can find which checks they are passing by measuring how long the function takes to run. This code still has some timing leaks, but they are greatly reduced.