### PR TITLE
Add Borrow in Verifier Loop

### DIFF
--- a/src/bin/sus-kernel/request.rs
+++ b/src/bin/sus-kernel/request.rs
@@ -61,7 +61,7 @@ impl Request {
     pub fn service(mut self) -> RequestResult {
         // Assert that all the verifications pass
         // Note the question mark to unwrap the result
-        for mut v in self.verifiers {
+        for v in &mut self.verifiers {
             v(
                 &self.current_permissions,
                 &self.requested_permissions,


### PR DESCRIPTION
Make it such that the verifier function is borrowed instead of owned. This way, we can still use the verifiers afterward.