### PR TITLE
Implement Logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,32 +27,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
-
-[[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "memoffset"
@@ -77,96 +55,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "simplelog"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8baa24de25f3092d9697c76f94cf09f67fca13db2ea11ce80c2f055c1aaf0795"
-dependencies = [
- "chrono",
- "log",
- "termcolor",
-]
-
-[[package]]
 name = "sus"
 version = "0.0.0"
 dependencies = [
  "nix",
- "simplelog",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
-]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -27,10 +27,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "libc"
-version = "0.2.106"
+name = "chrono"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "memoffset"
@@ -55,8 +77,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "simplelog"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8baa24de25f3092d9697c76f94cf09f67fca13db2ea11ce80c2f055c1aaf0795"
+dependencies = [
+ "chrono",
+ "log",
+ "termcolor",
+]
+
+[[package]]
 name = "sus"
 version = "0.0.0"
 dependencies = [
  "nix",
+ "simplelog",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.0.0"
 edition = "2021"
 
 [features]
-default = [ "logging" ]
-logging = []
+default = [ "log" ]
+log = []
 
 [[bin]]
 name = "sus-kernel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,10 @@ edition = "2021"
 
 [features]
 default = [ "logging" ]
-logging = [ "simplelog" ]
+logging = []
 
 [[bin]]
 name = "sus-kernel"
 
 [dependencies]
 nix = "0.23.0"
-simplelog = { version = "0.11.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = [ "log" ]
 log = []
+log_fail_msg = [ "log" ]
 
 [[bin]]
 name = "sus-kernel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,13 @@ name = "sus"
 version = "0.0.0"
 edition = "2021"
 
+[features]
+default = [ "logging" ]
+logging = [ "simplelog" ]
+
 [[bin]]
 name = "sus-kernel"
 
 [dependencies]
 nix = "0.23.0"
+simplelog = { version = "0.11.0", optional = true }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -12,6 +12,10 @@
 CARGO_MAKE_CLIPPY_ARGS = "-- -D warnings"
 
 
+# Pass the same features to `cargo check` as we do for the build
+[tasks.check]
+args = [ "check", "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )" ]
+
 # Run audit unconditionally
 [tasks.audit]
 condition = {}

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -43,7 +43,8 @@ dependencies = [
 
 # Task to build the application in release mode
 # It runs formatting and linting, but in check mode only. This task is for
-#  release builds, so the code should be good to go
+#  release builds, so the code should be good to go. Also, we don't need to
+#  explicitly do the configuration files. They will be copied over then checked.
 # It also generates documentation
 [tasks.sus-release-build]
 description = "Workflow to build and test SUS in release mode"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -60,6 +60,13 @@ dependencies = [
     "docs",
 ]
 
+# Task to build the application for end users
+# It calls into `sus-release-build`, except it doesn't have `--all-features`
+#  enabled. Only the default features are compiled.
+[tasks.sus-dist-build]
+env = { "CARGO_MAKE_CARGO_BUILD_TEST_FLAGS" = "" }
+run_task = "sus-release-build"
+
 
 # Task to install
 # We have to install the kernel as setuid root

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -81,7 +81,7 @@ pub const LOGGER: Logger = log::to_file;
 ///
 /// [rq]: crate::request::Request
 #[cfg(feature = "log")]
-pub const LOG_FILE_PATH: &str = "/var/log/sus.log";
+pub const LOG_FILE_PATH: &str = "/dev/stdout";
 /// The permissions to log with
 ///
 /// This configuration parameter sets the permissions that [log::to_file] will
@@ -134,12 +134,19 @@ pub(crate) use LOG_WRITE_SUCCESS_MSG;
 ///   * `execable`: The [Executable][eb] to execute
 ///   * `cur_perm`: The current [Permissions][pm] of the user
 ///   * `req_perm`: The [Permissions][pm] the user requested
-///   * `failure`: The [VerifyError][ve] reported
+///   * `failure`: The [VerifyError][ve] reported. Only provided if the
+///     `log_fail_msg` feature is enabled.
 ///
 /// [eb]: executable::Executable
 /// [pm]: permission::Permission
 /// [ve]: permission::verify::VerifyError
-#[cfg(feature = "log")]
+#[cfg(all(feature = "log", not(feature = "log_fail_msg")))]
+macro_rules! LOG_WRITE_FAILURE_MSG {
+    () => {
+        "{tstamp_secs}.{tstamp_nanos:0>9} FAILURE Executing {execable}; From {cur_perm}; To {req_perm}\n"
+    };
+}
+#[cfg(all(feature = "log", feature = "log_fail_msg"))]
 macro_rules! LOG_WRITE_FAILURE_MSG {
     () => {
         "{tstamp_secs}.{tstamp_nanos:0>9} FAILURE Executing {execable}; From {cur_perm}; To {req_perm}; Error {failure}\n"

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -76,7 +76,7 @@ pub const LOGGER: Logger = log::to_file;
 /// This path is hard-coded into the binary and cannot be changed at runtime.
 ///
 /// [rq]: crate::request::Request
-pub const LOG_FILE_PATH: &str = "/dev/stdout";
+pub const LOG_FILE_PATH: &str = "/var/log/sus.log";
 
 /// The format of the log message on success
 ///

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -128,7 +128,7 @@ pub(crate) use LOG_WRITE_SUCCESS_MSG;
 /// [ve]: permission::verify::VerifyError
 macro_rules! LOG_WRITE_FAILURE_MSG {
     () => {
-        "{tstamp_secs}.{tstamp_nanos:0>9} FAILURE Executing {execable}; From {cur_perm}; To {req_perm}; Error {failure:?}\n"
+        "{tstamp_secs}.{tstamp_nanos:0>9} FAILURE Executing {execable}; From {cur_perm}; To {req_perm}; Error {failure}\n"
     };
 }
 pub(crate) use LOG_WRITE_FAILURE_MSG;

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -12,6 +12,8 @@
 use crate::executable;
 use crate::executable::factory::AutoExecutableFactory;
 use crate::executable::run::Runner;
+use crate::log;
+use crate::log::Logger;
 use crate::permission;
 use crate::permission::factory::AutoPermissionFactory;
 use crate::permission::verify::Verifier;
@@ -57,6 +59,24 @@ pub const VERIFIERS: &[Verifier] = &[];
 ///
 /// [eb]: executable::Executable
 pub const RUNNER: Runner = executable::run::exec;
+
+/// How to log incoming [Request][rq]s
+///
+/// For administrative purposes, it might be useful to log what [Request][rq]s
+/// people make to this binary. This is the function that is called for logging.
+///
+/// [rq]: crate::request::Request
+pub const LOGGER: Logger = log::to_file;
+
+/// The path to log to
+///
+/// The [log::to_file] logger uses this path to determine where to log *all* the
+/// incoming [Request][rq]s, both successful and failed. As such, this log file
+/// can grow very quickly and should be rotated regularly, say with `logrotate`.
+/// This path is hard-coded into the binary and cannot be changed at runtime.
+///
+/// [rq]: crate::request::Request
+pub const LOG_FILE_PATH: &str = "/dev/stdout";
 
 /// What command line argument number to look for for the path of the binary to
 /// execute

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -87,12 +87,23 @@ pub const LOG_FILE_PATH: &str = "/dev/stdout";
 /// Note that this is a macro instead of a hard string literal. This is so that
 /// formatting string still works. The format string literal has to be in the
 /// code literally or as a macro. Thus, this solution.
-#[macro_export]
-macro_rules! CONFIG_LOG_SUCCESS_MSG {
+///
+/// The code provides the following variables for use
+///   * `tstamp_secs`: The current unix timestamp's whole number part in seconds
+///   * `tstamp_nanos`: The fractional part of the current unix timestamp in
+///     nanoseconds
+///   * `execable`: The [Executable][eb] to execute
+///   * `cur_perm`: The current [Permissions][pm] of the user
+///   * `req_perm`: The [Permissions][pm] the user requested
+///
+/// [eb]: executable::Executable
+/// [pm]: permission::Permission
+macro_rules! LOG_WRITE_SUCCESS_MSG {
     () => {
-        "{tstamp_sign}{tstamp_secs}.{tstamp_nanos}\n"
+        "{tstamp_secs}.{tstamp_nanos:0>9} SUCCESS Executing {execable}; From {cur_perm}; To {req_perm};\n"
     };
 }
+pub(crate) use LOG_WRITE_SUCCESS_MSG;
 /// The format of the log message on failure
 ///
 /// The logging functionality of this crate allows us to configure the messages
@@ -102,12 +113,25 @@ macro_rules! CONFIG_LOG_SUCCESS_MSG {
 /// Note that this is a macro instead of a hard string literal. This is so that
 /// formatting string still works. The format string literal has to be in the
 /// code literally or as a macro. Thus, this solution.
-#[macro_export]
-macro_rules! CONFIG_LOG_FAILURE_MSG {
+///
+/// The code provides the following variables for use
+///   * `tstamp_secs`: The current unix timestamp's whole number part in seconds
+///   * `tstamp_nanos`: The fractional part of the current unix timestamp in
+///     nanoseconds
+///   * `execable`: The [Executable][eb] to execute
+///   * `cur_perm`: The current [Permissions][pm] of the user
+///   * `req_perm`: The [Permissions][pm] the user requested
+///   * `failure`: The [VerifyError][ve] reported
+///
+/// [eb]: executable::Executable
+/// [pm]: permission::Permission
+/// [ve]: permission::verify::VerifyError
+macro_rules! LOG_WRITE_FAILURE_MSG {
     () => {
-        "{tstamp_sign}{tstamp_secs}.{tstamp_nanos}\n"
+        "{tstamp_secs}.{tstamp_nanos:0>9} FAILURE Executing {execable}; From {cur_perm}; To {req_perm}; Error {failure:?}\n"
     };
 }
+pub(crate) use LOG_WRITE_FAILURE_MSG;
 
 /// What command line argument number to look for for the path of the binary to
 /// execute

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -100,7 +100,7 @@ pub const LOG_FILE_PATH: &str = "/dev/stdout";
 /// [pm]: permission::Permission
 macro_rules! LOG_WRITE_SUCCESS_MSG {
     () => {
-        "{tstamp_secs}.{tstamp_nanos:0>9} SUCCESS Executing {execable}; From {cur_perm}; To {req_perm};\n"
+        "{tstamp_secs}.{tstamp_nanos:0>9} SUCCESS Executing {execable}; From {cur_perm}; To {req_perm}\n"
     };
 }
 pub(crate) use LOG_WRITE_SUCCESS_MSG;

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -77,6 +77,11 @@ pub const LOGGER: Logger = log::to_file;
 ///
 /// [rq]: crate::request::Request
 pub const LOG_FILE_PATH: &str = "/var/log/sus.log";
+/// The permissions to log with
+///
+/// This configuration parameter sets the permissions that [log::to_file] will
+/// set the log file. They will be set unconditionally.
+pub const LOG_FILE_PERMS: u32 = 0o400;
 
 /// The format of the log message on success
 ///

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -81,7 +81,7 @@ pub const LOGGER: Logger = log::to_file;
 ///
 /// [rq]: crate::request::Request
 #[cfg(feature = "log")]
-pub const LOG_FILE_PATH: &str = "/dev/stdout";
+pub const LOG_FILE_PATH: &str = "/var/log/sus.log";
 /// The permissions to log with
 ///
 /// This configuration parameter sets the permissions that [log::to_file] will

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -12,11 +12,14 @@
 use crate::executable;
 use crate::executable::factory::AutoExecutableFactory;
 use crate::executable::run::Runner;
-use crate::log;
-use crate::log::Logger;
 use crate::permission;
 use crate::permission::factory::AutoPermissionFactory;
 use crate::permission::verify::Verifier;
+
+#[cfg(feature = "logging")]
+use crate::log;
+#[cfg(feature = "logging")]
+use crate::log::Logger;
 
 /// The method to use to find the [Executable][eb] to run
 ///
@@ -66,6 +69,7 @@ pub const RUNNER: Runner = executable::run::exec;
 /// people make to this binary. This is the function that is called for logging.
 ///
 /// [rq]: crate::request::Request
+#[cfg(feature = "logging")]
 pub const LOGGER: Logger = log::to_file;
 
 /// The path to log to
@@ -76,11 +80,13 @@ pub const LOGGER: Logger = log::to_file;
 /// This path is hard-coded into the binary and cannot be changed at runtime.
 ///
 /// [rq]: crate::request::Request
+#[cfg(feature = "logging")]
 pub const LOG_FILE_PATH: &str = "/var/log/sus.log";
 /// The permissions to log with
 ///
 /// This configuration parameter sets the permissions that [log::to_file] will
 /// set the log file. They will be set unconditionally.
+#[cfg(feature = "logging")]
 pub const LOG_FILE_PERMS: u32 = 0o400;
 
 /// The format of the log message on success
@@ -103,11 +109,13 @@ pub const LOG_FILE_PERMS: u32 = 0o400;
 ///
 /// [eb]: executable::Executable
 /// [pm]: permission::Permission
+#[cfg(feature = "logging")]
 macro_rules! LOG_WRITE_SUCCESS_MSG {
     () => {
         "{tstamp_secs}.{tstamp_nanos:0>9} SUCCESS Executing {execable}; From {cur_perm}; To {req_perm}\n"
     };
 }
+#[cfg(feature = "logging")]
 pub(crate) use LOG_WRITE_SUCCESS_MSG;
 /// The format of the log message on failure
 ///
@@ -131,11 +139,13 @@ pub(crate) use LOG_WRITE_SUCCESS_MSG;
 /// [eb]: executable::Executable
 /// [pm]: permission::Permission
 /// [ve]: permission::verify::VerifyError
+#[cfg(feature = "logging")]
 macro_rules! LOG_WRITE_FAILURE_MSG {
     () => {
         "{tstamp_secs}.{tstamp_nanos:0>9} FAILURE Executing {execable}; From {cur_perm}; To {req_perm}; Error {failure}\n"
     };
 }
+#[cfg(feature = "logging")]
 pub(crate) use LOG_WRITE_FAILURE_MSG;
 
 /// What command line argument number to look for for the path of the binary to

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -16,9 +16,9 @@ use crate::permission;
 use crate::permission::factory::AutoPermissionFactory;
 use crate::permission::verify::Verifier;
 
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 use crate::log;
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 use crate::log::Logger;
 
 /// The method to use to find the [Executable][eb] to run
@@ -69,7 +69,7 @@ pub const RUNNER: Runner = executable::run::exec;
 /// people make to this binary. This is the function that is called for logging.
 ///
 /// [rq]: crate::request::Request
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 pub const LOGGER: Logger = log::to_file;
 
 /// The path to log to
@@ -80,13 +80,13 @@ pub const LOGGER: Logger = log::to_file;
 /// This path is hard-coded into the binary and cannot be changed at runtime.
 ///
 /// [rq]: crate::request::Request
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 pub const LOG_FILE_PATH: &str = "/var/log/sus.log";
 /// The permissions to log with
 ///
 /// This configuration parameter sets the permissions that [log::to_file] will
 /// set the log file. They will be set unconditionally.
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 pub const LOG_FILE_PERMS: u32 = 0o400;
 
 /// The format of the log message on success
@@ -109,13 +109,13 @@ pub const LOG_FILE_PERMS: u32 = 0o400;
 ///
 /// [eb]: executable::Executable
 /// [pm]: permission::Permission
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 macro_rules! LOG_WRITE_SUCCESS_MSG {
     () => {
         "{tstamp_secs}.{tstamp_nanos:0>9} SUCCESS Executing {execable}; From {cur_perm}; To {req_perm}\n"
     };
 }
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 pub(crate) use LOG_WRITE_SUCCESS_MSG;
 /// The format of the log message on failure
 ///
@@ -139,13 +139,13 @@ pub(crate) use LOG_WRITE_SUCCESS_MSG;
 /// [eb]: executable::Executable
 /// [pm]: permission::Permission
 /// [ve]: permission::verify::VerifyError
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 macro_rules! LOG_WRITE_FAILURE_MSG {
     () => {
         "{tstamp_secs}.{tstamp_nanos:0>9} FAILURE Executing {execable}; From {cur_perm}; To {req_perm}; Error {failure}\n"
     };
 }
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 pub(crate) use LOG_WRITE_FAILURE_MSG;
 
 /// What command line argument number to look for for the path of the binary to

--- a/config/sus-kernel.rs
+++ b/config/sus-kernel.rs
@@ -78,6 +78,37 @@ pub const LOGGER: Logger = log::to_file;
 /// [rq]: crate::request::Request
 pub const LOG_FILE_PATH: &str = "/dev/stdout";
 
+/// The format of the log message on success
+///
+/// The logging functionality of this crate allows us to configure the messages
+/// that are written on success and failure. This configuration parameter
+/// configures the success message.
+///
+/// Note that this is a macro instead of a hard string literal. This is so that
+/// formatting string still works. The format string literal has to be in the
+/// code literally or as a macro. Thus, this solution.
+#[macro_export]
+macro_rules! CONFIG_LOG_SUCCESS_MSG {
+    () => {
+        "{tstamp_sign}{tstamp_secs}.{tstamp_nanos}\n"
+    };
+}
+/// The format of the log message on failure
+///
+/// The logging functionality of this crate allows us to configure the messages
+/// that are written on success and failure. This configuration parameter
+/// configures the failure message.
+///
+/// Note that this is a macro instead of a hard string literal. This is so that
+/// formatting string still works. The format string literal has to be in the
+/// code literally or as a macro. Thus, this solution.
+#[macro_export]
+macro_rules! CONFIG_LOG_FAILURE_MSG {
+    () => {
+        "{tstamp_sign}{tstamp_secs}.{tstamp_nanos}\n"
+    };
+}
+
 /// What command line argument number to look for for the path of the binary to
 /// execute
 ///

--- a/src/bin/sus-kernel/executable/mod.rs
+++ b/src/bin/sus-kernel/executable/mod.rs
@@ -16,6 +16,8 @@ pub mod factory;
 pub mod run;
 
 use std::ffi::CString;
+use std::fmt;
+use std::fmt::{Display, Formatter};
 
 /// Structure representing an executable program
 ///
@@ -27,4 +29,18 @@ pub struct Executable {
     pub path: CString,
     /// The command line arguments to pass to the executable
     pub args: Vec<CString>,
+}
+
+impl Display for Executable {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // Write the path to the executable
+        write!(f, "\"{}\"", self.path.to_string_lossy())?;
+        // Write all the arguments
+        write!(f, " with arguments")?;
+        for a in &self.args {
+            write!(f, " \"{}\"", a.to_string_lossy())?;
+        }
+        // Return
+        Ok(())
+    }
 }

--- a/src/bin/sus-kernel/log/file.rs
+++ b/src/bin/sus-kernel/log/file.rs
@@ -29,12 +29,13 @@ use std::fs::OpenOptions;
 /// [w]: std::io::Write
 pub fn to_file(req: &Request, res: &VerifyResult) -> LoggerResult {
     // Open the file in append mode
-    let f = OpenOptions::new()
+    let mut f = OpenOptions::new()
+        .create(true)
         .append(true)
         .open(config::LOG_FILE_PATH)?;
 
     // Pass it to the logger and return
     // Don't need to close the file. It will automatically be closed when the
     //  scope ends
-    to_write(f, req, res)
+    to_write(&mut f, req, res)
 }

--- a/src/bin/sus-kernel/log/file.rs
+++ b/src/bin/sus-kernel/log/file.rs
@@ -6,7 +6,7 @@
 //! [rq]: crate::request::Request
 
 use super::to_write;
-use super::LoggerResult;
+use super::LogResult;
 
 use crate::config;
 use crate::executable::Executable;
@@ -41,7 +41,7 @@ pub fn to_file(
     cur_p: &Permission,
     req_p: &Permission,
     res: &VerifyResult,
-) -> LoggerResult {
+) -> LogResult {
     // Open the file in append mode
     let mut f = OpenOptions::new()
         .create(true)

--- a/src/bin/sus-kernel/log/file.rs
+++ b/src/bin/sus-kernel/log/file.rs
@@ -1,33 +1,47 @@
-//! Log [Request]s to a pre-configured file
+//! Log [Request][rq]s to a pre-configured file
 //!
-//! The function in this module is used to log [Request]s to a file. The path to
-//! file is configured at compile time in the [config] module.
+//! The function in this module is used to log [Request][rq]s to a file. The
+//! path to file is configured at compile time in the [config] module.
+//!
+//! [rq]: crate::request::Request
 
 use super::to_write;
 use super::LoggerResult;
 
 use crate::config;
+use crate::executable::Executable;
 use crate::permission::verify::VerifyResult;
-use crate::request::Request;
+use crate::permission::Permission;
 
 use std::fs::OpenOptions;
 
-/// Function to log a given [Request] and [VerifyResult] to a file
+/// Function to log a given [Request][rq] and [VerifyResult] to a file
 ///
 /// Effectively, this function is a wrapper around the [to_write] logger, which
 /// writes to an arbitrary [Write][w] object. This can be done since [File][f]s
 /// implement [Write][w]. This method will open the [File][f], pass it off, and
 /// close it when done.
 ///
+/// As stated in the top-level documentation, this function does not take in the
+/// [Request][rq] directly since that leads to conflicts with mutability.
+/// Instead, it takes in the components it needs: the actual [Executable] run,
+/// the Current [Permission], and the Requested [Permission].
+///
 /// The path to the file to be used is pre-configured. It is given by
 /// [config::LOG_FILE_PATH].
 ///
 /// This function can error out on its own if it fails to open the file for
-/// appending.
+/// appending
 ///
 /// [f]: std::fs::File
 /// [w]: std::io::Write
-pub fn to_file(req: &Request, res: &VerifyResult) -> LoggerResult {
+/// [rq]: crate::request::Request
+pub fn to_file(
+    ex: &Executable,
+    cur_p: &Permission,
+    req_p: &Permission,
+    res: &VerifyResult,
+) -> LoggerResult {
     // Open the file in append mode
     let mut f = OpenOptions::new()
         .create(true)
@@ -37,5 +51,5 @@ pub fn to_file(req: &Request, res: &VerifyResult) -> LoggerResult {
     // Pass it to the logger and return
     // Don't need to close the file. It will automatically be closed when the
     //  scope ends
-    to_write(&mut f, req, res)
+    to_write(&mut f, ex, cur_p, req_p, res)
 }

--- a/src/bin/sus-kernel/log/file.rs
+++ b/src/bin/sus-kernel/log/file.rs
@@ -1,0 +1,40 @@
+//! Log [Request]s to a pre-configured file
+//!
+//! The function in this module is used to log [Request]s to a file. The path to
+//! file is configured at compile time in the [config] module.
+
+use super::to_write;
+use super::LoggerResult;
+
+use crate::config;
+use crate::permission::verify::VerifyResult;
+use crate::request::Request;
+
+use std::fs::OpenOptions;
+
+/// Function to log a given [Request] and [VerifyResult] to a file
+///
+/// Effectively, this function is a wrapper around the [to_write] logger, which
+/// writes to an arbitrary [Write][w] object. This can be done since [File][f]s
+/// implement [Write][w]. This method will open the [File][f], pass it off, and
+/// close it when done.
+///
+/// The path to the file to be used is pre-configured. It is given by
+/// [config::LOG_FILE_PATH].
+///
+/// This function can error out on its own if it fails to open the file for
+/// appending.
+///
+/// [f]: std::fs::File
+/// [w]: std::io::Write
+pub fn to_file(rq: &Request, res: &VerifyResult) -> LoggerResult {
+    // Open the file in append mode
+    let f = OpenOptions::new()
+        .append(true)
+        .open(config::LOG_FILE_PATH)?;
+
+    // Pass it to the logger and return
+    // Don't need to close the file. It will automatically be closed when the
+    //  scope ends
+    to_write(f, rq, res)
+}

--- a/src/bin/sus-kernel/log/file.rs
+++ b/src/bin/sus-kernel/log/file.rs
@@ -27,7 +27,7 @@ use std::fs::OpenOptions;
 ///
 /// [f]: std::fs::File
 /// [w]: std::io::Write
-pub fn to_file(rq: &Request, res: &VerifyResult) -> LoggerResult {
+pub fn to_file(req: &Request, res: &VerifyResult) -> LoggerResult {
     // Open the file in append mode
     let f = OpenOptions::new()
         .append(true)
@@ -36,5 +36,5 @@ pub fn to_file(rq: &Request, res: &VerifyResult) -> LoggerResult {
     // Pass it to the logger and return
     // Don't need to close the file. It will automatically be closed when the
     //  scope ends
-    to_write(f, rq, res)
+    to_write(f, req, res)
 }

--- a/src/bin/sus-kernel/log/file.rs
+++ b/src/bin/sus-kernel/log/file.rs
@@ -14,6 +14,8 @@ use crate::permission::verify::VerifyResult;
 use crate::permission::Permission;
 
 use std::fs::OpenOptions;
+use std::fs::Permissions;
+use std::os::unix::fs::PermissionsExt;
 
 /// Function to log a given [Request][rq] and [VerifyResult] to a file
 ///
@@ -28,7 +30,9 @@ use std::fs::OpenOptions;
 /// the Current [Permission], and the Requested [Permission].
 ///
 /// The path to the file to be used is pre-configured. It is given by
-/// [config::LOG_FILE_PATH].
+/// [config::LOG_FILE_PATH]. The same is true for the permissions of the file.
+/// The file permissions will be changed to [config::LOG_FILE_PERMS]
+/// unconditionally.
 ///
 /// This function can error out on its own if it fails to open the file for
 /// appending
@@ -47,6 +51,9 @@ pub fn to_file(
         .create(true)
         .append(true)
         .open(config::LOG_FILE_PATH)?;
+
+    // Set the file mode
+    f.set_permissions(Permissions::from_mode(config::LOG_FILE_PERMS))?;
 
     // Pass it to the logger and return
     // Don't need to close the file. It will automatically be closed when the

--- a/src/bin/sus-kernel/log/mod.rs
+++ b/src/bin/sus-kernel/log/mod.rs
@@ -4,3 +4,35 @@
 //! to elevate privileges. As such, this module provides methods to do so.
 //! The core of this module is the [Logger] and corresponding [AbstractLogger],
 //! which log accesses using a [Request] and a [VerifyResult].
+
+pub mod file;
+pub mod write;
+pub use file::to_file;
+pub use write::to_write;
+
+use crate::permission::verify::VerifyResult;
+use crate::request::Request;
+
+use std::error::Error;
+
+/// Type for logging functions
+///
+/// These functions take in the [Request] that was serviced and the
+/// [VerifyResult] that came out of it. When called, they will log their
+/// parameters in some way.
+pub type Logger = fn(&Request, &VerifyResult) -> LoggerResult;
+/// Abstract supetype of [Logger]
+///
+/// Keeping with how this crate handles verification and execution, this
+/// supertype exists so that we can construct [Logger]s at runtime, not being
+/// restricted to the [Sized] function pointer type. This might be useful when
+/// constructing tests.
+pub type AbstractLogger = dyn FnMut(&Request, &VerifyResult) -> LoggerResult;
+
+/// Result type for [Logger]s
+///
+/// Loggers may return arbitrary errors in the process of writing the data out.
+/// As such, it will either succeed with no message, or return a [Box]
+/// containing an [Error]. It makes little sense to have a `LoggerError` type
+/// since it would provide no other information above the [Error].
+pub type LoggerResult = Result<(), Box<dyn Error>>;

--- a/src/bin/sus-kernel/log/mod.rs
+++ b/src/bin/sus-kernel/log/mod.rs
@@ -31,7 +31,7 @@ use std::error::Error;
 /// we actually need.
 ///
 /// [rq]: crate::request::Request
-pub type Logger = fn(&Executable, &Permission, &Permission, &VerifyResult) -> LoggerResult;
+pub type Logger = fn(&Executable, &Permission, &Permission, &VerifyResult) -> LogResult;
 /// Abstract supetype of [Logger]
 ///
 /// Keeping with how this crate handles verification and execution, this
@@ -39,12 +39,16 @@ pub type Logger = fn(&Executable, &Permission, &Permission, &VerifyResult) -> Lo
 /// restricted to the [Sized] function pointer type. This might be useful when
 /// constructing tests.
 pub type AbstractLogger =
-    dyn FnMut(&Executable, &Permission, &Permission, &VerifyResult) -> LoggerResult;
+    dyn FnMut(&Executable, &Permission, &Permission, &VerifyResult) -> LogResult;
 
 /// Result type for [Logger]s
 ///
-/// Loggers may return arbitrary errors in the process of writing the data out.
-/// As such, it will either succeed with no message, or return a [Box]
-/// containing an [Error]. It makes little sense to have a `LoggerError` type
-/// since it would provide no other information above the [Error].
-pub type LoggerResult = Result<(), Box<dyn Error>>;
+/// [Logger]s may return arbitrary errors in the process of writing the data
+/// out. On success, they don't return anything. This type captures that.
+pub type LogResult = Result<(), LogError>;
+/// Error type for [Logger]s
+///
+/// [Logger]s may return arbitrary errors in the process of writing the data
+/// out. As such, this type is really only provided for convenience. It's an
+/// alias to a general error [Box].
+pub type LogError = Box<dyn Error>;

--- a/src/bin/sus-kernel/log/mod.rs
+++ b/src/bin/sus-kernel/log/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! [rq]: crate::request::Request
 
-#![cfg(feature = "logging")]
+#![cfg(feature = "log")]
 
 pub mod file;
 pub use file::to_file;

--- a/src/bin/sus-kernel/log/mod.rs
+++ b/src/bin/sus-kernel/log/mod.rs
@@ -1,0 +1,6 @@
+//! Module to log accesses
+//!
+//! Often, system administrators will want to log when a user uses this binary
+//! to elevate privileges. As such, this module provides methods to do so.
+//! The core of this module is the [Logger] and corresponding [AbstractLogger],
+//! which log accesses using a [Request] and a [VerifyResult].

--- a/src/bin/sus-kernel/log/mod.rs
+++ b/src/bin/sus-kernel/log/mod.rs
@@ -7,6 +7,8 @@
 //!
 //! [rq]: crate::request::Request
 
+#![cfg(feature = "logging")]
+
 pub mod file;
 pub use file::to_file;
 

--- a/src/bin/sus-kernel/log/write.rs
+++ b/src/bin/sus-kernel/log/write.rs
@@ -5,10 +5,14 @@
 //! That is what this module does. It will log a pretty-printed string to the
 //! [Write] object.
 //!
+//! For logging, this module uses [SystemTime] instead of [Instant][inst]. As a
+//! result, the timestamps are not monotonic. Be aware of that.
+//!
 //! Note that the results of this module are intended for human use. Everything
 //! will be pretty-printed.
 //!
 //! [f]: std::fs::File
+//! [inst]: std::time::Instant
 
 use super::LoggerResult;
 
@@ -16,10 +20,28 @@ use crate::permission::verify::VerifyResult;
 use crate::request::Request;
 
 use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn to_write<W>(_: W, _: &Request, _: &VerifyResult) -> LoggerResult
+pub fn to_write<W>(w: &mut W, _: &Request, _: &VerifyResult) -> LoggerResult
 where
     W: Write,
 {
+    // Get the Duration since the epoch
+    // Don't fail if we're before the epoch. Instead, just print a negative
+    //  number.
+    let (tstamp_is_neg, tstamp) = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(res) => (false, res),
+        Err(e) => (true, e.duration()),
+    };
+
+    // Write out
+    write!(
+        w,
+        "{tstamp_sign}{tstamp_secs}.{tstamp_nanos:0<9}",
+        tstamp_sign = if tstamp_is_neg { "-" } else { " " },
+        tstamp_secs = tstamp.as_secs(),
+        tstamp_nanos = tstamp.subsec_nanos(),
+    )?;
+
     Ok(())
 }

--- a/src/bin/sus-kernel/log/write.rs
+++ b/src/bin/sus-kernel/log/write.rs
@@ -58,6 +58,11 @@ where
             cur_perm = cur_p,
             req_perm = req_p,
         ),
+
+        // Have different handling based on features
+        // If the `log_fail_msg` feature is enabled, we should provide the error
+        //  to the log. Otherwise, we should not.
+        #[cfg(feature = "log_fail_msg")]
         Err(e) => write!(
             w,
             config::LOG_WRITE_FAILURE_MSG!(),
@@ -67,6 +72,16 @@ where
             cur_perm = cur_p,
             req_perm = req_p,
             failure = e,
+        ),
+        #[cfg(not(feature = "log_fail_msg"))]
+        Err(_) => write!(
+            w,
+            config::LOG_WRITE_FAILURE_MSG!(),
+            tstamp_secs = tstamp_negation * (tstamp.as_secs() as i128),
+            tstamp_nanos = tstamp.subsec_nanos(),
+            execable = ex,
+            cur_perm = cur_p,
+            req_perm = req_p,
         ),
     }?;
 

--- a/src/bin/sus-kernel/log/write.rs
+++ b/src/bin/sus-kernel/log/write.rs
@@ -1,0 +1,25 @@
+//! Log [Request]s to an existing [Write] object
+//!
+//! Even though we will likely be logging to [File][f]s most of the time, it
+//! would be nice to be able to log to a generic object implementing [Write].
+//! That is what this module does. It will log a pretty-printed string to the
+//! [Write] object.
+//!
+//! Note that the results of this module are intended for human use. Everything
+//! will be pretty-printed.
+//!
+//! [f]: std::fs::File
+
+use super::LoggerResult;
+
+use crate::permission::verify::VerifyResult;
+use crate::request::Request;
+
+use std::io::Write;
+
+pub fn to_write<W>(_: W, _: &Request, _: &VerifyResult) -> LoggerResult
+where
+    W: Write,
+{
+    Ok(())
+}

--- a/src/bin/sus-kernel/log/write.rs
+++ b/src/bin/sus-kernel/log/write.rs
@@ -1,4 +1,4 @@
-//! Log [Request]s to an existing [Write] object
+//! Log [Request][rq]s to an existing [Write] object
 //!
 //! Even though we will likely be logging to [File][f]s most of the time, it
 //! would be nice to be able to log to a generic object implementing [Write].
@@ -13,16 +13,24 @@
 //!
 //! [f]: std::fs::File
 //! [inst]: std::time::Instant
+//! [rq]: crate::request::Request
 
 use super::LoggerResult;
 
+use crate::executable::Executable;
 use crate::permission::verify::VerifyResult;
-use crate::request::Request;
+use crate::permission::Permission;
 
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn to_write<W>(w: &mut W, _: &Request, _: &VerifyResult) -> LoggerResult
+pub fn to_write<W>(
+    w: &mut W,
+    _: &Executable,
+    _: &Permission,
+    _: &Permission,
+    _: &VerifyResult,
+) -> LoggerResult
 where
     W: Write,
 {

--- a/src/bin/sus-kernel/main.rs
+++ b/src/bin/sus-kernel/main.rs
@@ -14,7 +14,7 @@ mod request;
 use permission::verify::AbstractVerifier;
 use request::Request;
 
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 use log::AbstractLogger;
 
 /// Method to get the [Logger][lg] to use
@@ -25,7 +25,7 @@ use log::AbstractLogger;
 /// Thus, for optional features we define these separate functions.
 ///
 /// [lg]: log::Logger
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 fn get_logger() -> Box<AbstractLogger> {
     Box::new(config::LOGGER)
 }
@@ -78,7 +78,7 @@ fn main() {
         verifiers,
         runner,
         // Logging functionality
-        #[cfg(feature = "logging")]
+        #[cfg(feature = "log")]
         logger: get_logger(),
     };
     // Service the request

--- a/src/bin/sus-kernel/main.rs
+++ b/src/bin/sus-kernel/main.rs
@@ -35,7 +35,9 @@ fn main() {
     let current_permissions = config::CURRENT_PERMISSION_FACTORY().unwrap();
     let requested_permissions = config::REQUESTED_PERMISSION_FACTORY().unwrap();
     // Put the runner in a box
+    // Do the same with the logger
     let runner = Box::new(config::RUNNER);
+    let logger = Box::new(config::LOGGER);
 
     // Create the verifiers
     // We need to clone them from the slice reference
@@ -58,6 +60,7 @@ fn main() {
         requested_permissions,
         verifiers,
         runner,
+        logger,
     };
     req.service().unwrap();
 }

--- a/src/bin/sus-kernel/main.rs
+++ b/src/bin/sus-kernel/main.rs
@@ -7,6 +7,7 @@
 
 mod config;
 mod executable;
+mod log;
 mod permission;
 mod request;
 

--- a/src/bin/sus-kernel/main.rs
+++ b/src/bin/sus-kernel/main.rs
@@ -51,7 +51,6 @@ fn main() {
     let current_permissions = config::CURRENT_PERMISSION_FACTORY().unwrap();
     let requested_permissions = config::REQUESTED_PERMISSION_FACTORY().unwrap();
     // Put the runner in a box
-    // Do the same with the logger
     let runner = Box::new(config::RUNNER);
 
     // Create the verifiers

--- a/src/bin/sus-kernel/permission/mod.rs
+++ b/src/bin/sus-kernel/permission/mod.rs
@@ -13,6 +13,8 @@ pub mod verify;
 
 use nix::unistd::{Gid, Uid};
 use std::collections::HashSet;
+use std::fmt;
+use std::fmt::{Display, Formatter};
 
 /// Structure representing a permission set
 ///
@@ -28,4 +30,33 @@ pub struct Permission {
     /// A set of secondary group ids, which may or may not contain the primary
     /// group id itself
     pub secondary_gids: HashSet<Gid>,
+}
+
+impl Display for Permission {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // Handle the Secondary GIDs
+        // Frist, collect them and convert all of them to integers
+        // Then, sort the list
+        // Finally, convert all of them to strings
+        let sgid_vec: Vec<_> = {
+            // Step 1
+            let mut sgid_int_vec: Vec<_> = self.secondary_gids.iter().map(|g| g.as_raw()).collect();
+            // Step 2
+            // Must be done separately because no way to sort in place
+            sgid_int_vec.sort_unstable();
+            // Step 3
+            // Return
+            sgid_int_vec.into_iter().map(|g| g.to_string()).collect()
+        };
+        // Write everything
+        write!(
+            f,
+            "uid={} gid={} groups={}",
+            self.uid.as_raw(),
+            self.primary_gid.as_raw(),
+            sgid_vec.join(","),
+        )?;
+        // Return
+        Ok(())
+    }
 }

--- a/src/bin/sus-kernel/permission/verify/mod.rs
+++ b/src/bin/sus-kernel/permission/verify/mod.rs
@@ -9,6 +9,8 @@ use super::Permission;
 use crate::executable::Executable;
 
 use std::error::Error;
+use std::fmt;
+use std::fmt::{Display, Formatter};
 
 /// Type for verification functions
 ///
@@ -41,9 +43,30 @@ pub type VerifyResult = Result<(), VerifyError>;
 #[derive(Debug)]
 pub enum VerifyError {
     /// The user is not allowed to run the [Executable]
-    NotAllowed,
+    NotAllowed { err: Box<dyn Error> },
     /// Some component needed for verification was not found
     NotFound { err: Box<dyn Error> },
     /// Some component needed for verification could not be parsed
     Malformed { err: Box<dyn Error> },
+}
+
+impl Display for VerifyError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // Write different things depending on the type
+        match self {
+            // Special message if not allowed
+            VerifyError::NotAllowed { err } => {
+                write!(f, "Access denied because {}", err)?;
+            }
+            // Internal errors
+            VerifyError::NotFound { err } => {
+                write!(f, "Internal error NotFound - {}", err)?;
+            }
+            VerifyError::Malformed { err } => {
+                write!(f, "Internal error Malformed - {}", err)?;
+            }
+        }
+        // Return
+        Ok(())
+    }
 }

--- a/src/bin/sus-kernel/permission/verify/mod.rs
+++ b/src/bin/sus-kernel/permission/verify/mod.rs
@@ -56,14 +56,14 @@ impl Display for VerifyError {
         match self {
             // Special message if not allowed
             VerifyError::NotAllowed { err } => {
-                write!(f, "Access denied because {}", err)?;
+                write!(f, "Access Denied - {}", err)?;
             }
             // Internal errors
             VerifyError::NotFound { err } => {
-                write!(f, "Internal error NotFound - {}", err)?;
+                write!(f, "Internal Error NotFound - {}", err)?;
             }
             VerifyError::Malformed { err } => {
-                write!(f, "Internal error Malformed - {}", err)?;
+                write!(f, "Internal Error Malformed - {}", err)?;
             }
         }
         // Return

--- a/src/bin/sus-kernel/request.rs
+++ b/src/bin/sus-kernel/request.rs
@@ -9,6 +9,7 @@
 use crate::executable::run::AbstractRunner;
 use crate::executable::run::RunError;
 use crate::executable::Executable;
+use crate::log::AbstractLogger;
 use crate::permission::verify::AbstractVerifier;
 use crate::permission::verify::VerifyError;
 use crate::permission::verify::VerifyResult;
@@ -45,6 +46,15 @@ pub struct Request {
     pub verifiers: Vec<Box<AbstractVerifier>>,
     /// How to run the [Executable]
     pub runner: Box<AbstractRunner>,
+
+    /// How to log [Request]s
+    ///
+    /// Regardless of whether it passed all the [Verifiers][vf], this function
+    /// will be called with the status. This function can then log the result
+    /// somewhere for administration purposes.
+    ///
+    /// [vf]: crate::permission::verify::Verifier
+    pub logger: Box<AbstractLogger>,
 }
 
 impl Request {

--- a/src/bin/sus-kernel/request.rs
+++ b/src/bin/sus-kernel/request.rs
@@ -76,7 +76,7 @@ impl Request {
         // Note the question mark to unwrap the result
         let verify_res = {
             let mut res: VerifyResult = Ok(());
-            for mut v in self.verifiers {
+            for v in &mut self.verifiers {
                 res = res.and(v(
                     &self.current_permissions,
                     &self.requested_permissions,

--- a/src/bin/sus-kernel/request.rs
+++ b/src/bin/sus-kernel/request.rs
@@ -14,7 +14,7 @@ use crate::permission::verify::VerifyError;
 use crate::permission::verify::VerifyResult;
 use crate::permission::Permission;
 
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 use crate::log::{AbstractLogger, LogError};
 
 use std::convert::Infallible;
@@ -56,7 +56,7 @@ pub struct Request {
     /// somewhere for administration purposes.
     ///
     /// [vf]: crate::permission::verify::Verifier
-    #[cfg(feature = "logging")]
+    #[cfg(feature = "log")]
     pub logger: Box<AbstractLogger>,
 }
 
@@ -90,7 +90,7 @@ impl Request {
         };
         // Log the attempt result
         // Fail out immediately if we can't
-        #[cfg(feature = "logging")]
+        #[cfg(feature = "log")]
         {
             (self.logger)(
                 &self.executable,
@@ -130,7 +130,7 @@ pub enum RequestError {
     /// An error occured during verification
     Verify { cause: VerifyError },
     /// An error occured when trying to log
-    #[cfg(feature = "logging")]
+    #[cfg(feature = "log")]
     Log { cause: LogError },
     /// An error occurred when trying to run the [Executable]
     Run { cause: RunError },


### PR DESCRIPTION
For adminstrative purposes, it is often useful to log accesses to any `sudo`-like binary. This Pull Request adds this logging functionality to `sus`.

It makes a few large changes. First, it introduces `Display` implementations for the structures `Executable`, `Permission`, and `VerifyError`. This is so that they can be formatted in a human-readable way for the log file. Second, it introduces the `log` module, which provides methods to log out `to_file` or `to_write`. Accordingly, the `Request` structure is augmented with a `logger` field, and the `main` function populates it. Finally, it adds the `log` and `log_fail_msg` features so this functionality can be disabled if desired.

The `log` feature is fairly straightforward, controlling whether the enitre `log` module is used. The `log_fail_msg` is slightly more interesting. It might be unwise to log exactly what failure caused a user to not be able to authenticate. As such, this feature is disabled by default, preventing the failure message from being logged. The feature can be enabled to log the failure message too.

Many `config` options were added. Most important are `LOG_FILE_PATH` and `LOG_FILE_PERMS`. The former is the path to the log file, while the latter is the permissions the log should have. The log file will have its permissions brought into line with `LOG_FILE_PERMS` every time a log happens.

Aside from logging, some `Makefile` errors were corrected.

Closes #5