### PR TITLE
Add Userspace Binary

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,7 @@ jobs:
           name: Binaries
           path: |
             target/release/sus-kernel
+            target/release/sus
       - name: Capture docs
         uses: actions/upload-artifact@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +252,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "users",
+ "which",
 ]
 
 [[package]]
@@ -307,6 +314,17 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,10 +47,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -67,6 +126,30 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -125,12 +208,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sus"
 version = "0.0.0"
 dependencies = [
  "nix",
  "serde",
  "serde_json",
+ "structopt",
  "users",
 ]
 
@@ -144,6 +258,27 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -160,3 +295,37 @@ dependencies = [
  "libc",
  "log",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version="1.0.130", features = ["derive"] }
 serde_json = "1.0.67"
 users = "0.11.0"
 structopt = "0.3.25"
+which = "4.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ log_fail_msg = [ "log" ]
 [[bin]]
 name = "sus-kernel"
 
+[[bin]]
+name = "sus"
+
 [dependencies]
 nix = "0.23.0"
 serde = { version="1.0.130", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ nix = "0.23.0"
 serde = { version="1.0.130", features = ["derive"] }
 serde_json = "1.0.67"
 users = "0.11.0"
+structopt = "0.3.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.0.0"
 edition = "2021"
 
 [features]
-default = [ "log" ]
+default = [ "log", "sus" ]
+sus = [ "structopt", "which" ]
 log = []
 log_fail_msg = [ "log" ]
 
@@ -13,11 +14,12 @@ name = "sus-kernel"
 
 [[bin]]
 name = "sus"
+required-features = [ "sus" ]
 
 [dependencies]
 nix = "0.23.0"
 serde = { version="1.0.130", features = ["derive"] }
 serde_json = "1.0.67"
 users = "0.11.0"
-structopt = "0.3.25"
-which = "4.2.2"
+structopt = { version="0.3.25", optional = true }
+which = { version="4.2.2", optional = true }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -99,6 +99,13 @@ script = '''
         --no-target-directory \
         "config/sample/sudoers.json" "${SUS_SUDOERS_PATH}"
 
+    # Install the main userspace interface
+    install \
+        --mode=755 \
+        --strip \
+        --target-directory="${SUS_INSTALL_PREFIX}/${SUS_INSTALL_DIRECTORY}" \
+        "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/release/sus"
+
 '''
 
 

--- a/build.rs
+++ b/build.rs
@@ -11,10 +11,16 @@ struct CopySet {
 }
 
 /// The list of copies to perform
-const COPIES: &[CopySet] = &[CopySet {
-    old: "config/sus-kernel.rs",
-    new: "src/bin/sus-kernel/config.rs",
-}];
+const COPIES: &[CopySet] = &[
+    CopySet {
+        old: "config/sus-kernel.rs",
+        new: "src/bin/sus-kernel/config.rs",
+    },
+    CopySet {
+        old: "config/sus.rs",
+        new: "src/bin/sus/config.rs",
+    },
+];
 
 fn main() -> Result<(), std::io::Error> {
     // Do every copy

--- a/config/sus.rs
+++ b/config/sus.rs
@@ -14,27 +14,17 @@
 /// The path to the kernel
 pub const KERNEL_PATH: &str = "/usr/local/bin/sus-kernel";
 
-/// What command line argument number to look for for the path of the binary to
-/// execute
-///
-/// Used by [executable::factory::from_commandline]
-pub const KERNEL_COMMANDLINE_PATH_IDX: usize = 4;
-/// What command line argument number to use as the first parameter to the
+/// What command line argument number to put the path of the binary to execute
+/// at
+pub const KERNEL_COMMANDLINE_BINARY_IDX: usize = 3;
+/// What command line argument number to use for the first parameter to the
 /// program, with subsequent arguments being used in order
-///
-/// Used by [executable::factory::from_commandline]
-pub const KERNEL_COMMANDLINE_ARG_START_IDX: usize = 5;
+pub const KERNEL_COMMANDLINE_ARG_START_IDX: usize = 4;
 
-/// What command line argument number to look at for the UID
-///
-/// Used by [permission::factory::from_commandline]
-pub const KERNEL_COMMANDLINE_UID_IDX: usize = 1;
-/// What command line argument number to look at for the Primary GID
-///
-/// Used by [permission::factory::from_commandline]
-pub const KERNEL_COMMANDLINE_PRIMARY_GID_IDX: usize = 2;
-/// What command line argument number to look at for a comma separated list of
-/// the Secondary GIDs.
-///
-/// Used by [permission::factory::from_commandline]
-pub const KERNEL_COMMANDLINE_SECONDARY_GID_IDX: usize = 3;
+/// What command line argument number to put the UID at
+pub const KERNEL_COMMANDLINE_UID_IDX: usize = 0;
+/// What command line argument number to put the Primary GID at
+pub const KERNEL_COMMANDLINE_PRIMARY_GID_IDX: usize = 1;
+/// What command line argument number to put a comma separated list of the
+/// Secondary GIDs at
+pub const KERNEL_COMMANDLINE_SECONDARY_GID_IDX: usize = 2;

--- a/config/sus.rs
+++ b/config/sus.rs
@@ -1,0 +1,40 @@
+//! Configuration variables for the user-interface of SUS
+//!
+//! This file defines the configuration constants for the user-space `sus`
+//! program. These will be compiled into the final binary. Many of them must
+//! also align with other configuration files, otherwise the user-space binary
+//! will not work properly.
+//!
+//! Make sure to edit this file in `config/`. This file is copied to the `src/`
+//! directory as part of the build process. Any changes made there will be
+//! ignored by `cargo build`.
+
+#![allow(dead_code)]
+
+/// The path to the kernel
+pub const KERNEL_PATH: &str = "/usr/local/bin/sus-kernel";
+
+/// What command line argument number to look for for the path of the binary to
+/// execute
+///
+/// Used by [executable::factory::from_commandline]
+pub const KERNEL_COMMANDLINE_PATH_IDX: usize = 4;
+/// What command line argument number to use as the first parameter to the
+/// program, with subsequent arguments being used in order
+///
+/// Used by [executable::factory::from_commandline]
+pub const KERNEL_COMMANDLINE_ARG_START_IDX: usize = 5;
+
+/// What command line argument number to look at for the UID
+///
+/// Used by [permission::factory::from_commandline]
+pub const KERNEL_COMMANDLINE_UID_IDX: usize = 1;
+/// What command line argument number to look at for the Primary GID
+///
+/// Used by [permission::factory::from_commandline]
+pub const KERNEL_COMMANDLINE_PRIMARY_GID_IDX: usize = 2;
+/// What command line argument number to look at for a comma separated list of
+/// the Secondary GIDs.
+///
+/// Used by [permission::factory::from_commandline]
+pub const KERNEL_COMMANDLINE_SECONDARY_GID_IDX: usize = 3;

--- a/config/sus.rs
+++ b/config/sus.rs
@@ -16,15 +16,15 @@ pub const KERNEL_PATH: &str = "/usr/local/bin/sus-kernel";
 
 /// What command line argument number to put the path of the binary to execute
 /// at
-pub const KERNEL_COMMANDLINE_BINARY_IDX: usize = 3;
+pub const KERNEL_COMMANDLINE_BINARY_IDX: usize = 4;
 /// What command line argument number to use for the first parameter to the
 /// program, with subsequent arguments being used in order
-pub const KERNEL_COMMANDLINE_ARG_START_IDX: usize = 4;
+pub const KERNEL_COMMANDLINE_ARG_START_IDX: usize = 5;
 
 /// What command line argument number to put the UID at
-pub const KERNEL_COMMANDLINE_UID_IDX: usize = 0;
+pub const KERNEL_COMMANDLINE_UID_IDX: usize = 1;
 /// What command line argument number to put the Primary GID at
-pub const KERNEL_COMMANDLINE_PRIMARY_GID_IDX: usize = 1;
+pub const KERNEL_COMMANDLINE_PRIMARY_GID_IDX: usize = 2;
 /// What command line argument number to put a comma separated list of the
 /// Secondary GIDs at
-pub const KERNEL_COMMANDLINE_SECONDARY_GID_IDX: usize = 2;
+pub const KERNEL_COMMANDLINE_SECONDARY_GID_IDX: usize = 3;

--- a/src/bin/sus/main.rs
+++ b/src/bin/sus/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello world!");
+}

--- a/src/bin/sus/main.rs
+++ b/src/bin/sus/main.rs
@@ -1,11 +1,15 @@
 mod option;
 
-use option::CommandLineOptions;
-use option::Options;
+use std::error::Error;
 use structopt::StructOpt;
 
-fn main() {
+use option::CommandLineOptions;
+use option::Options;
+
+fn main() -> Result<(), Box<dyn Error>> {
     let command_line_opts = CommandLineOptions::from_args();
-    let opts = Options::parse_options_like(command_line_opts);
-    println!("{:?}", opts);
+    let opts = Options::parse_options_like(command_line_opts)?;
+    println!("{:?}", opts.to_kernel_commandline()?);
+
+    Ok(())
 }

--- a/src/bin/sus/main.rs
+++ b/src/bin/sus/main.rs
@@ -1,3 +1,9 @@
+//! User binary for SUS
+//!
+//! Ideally, the user would not invoke the kernel directly. Instead, they would
+//! do so through this intermediate binary. It provides a `sudo`-like interface
+//! for ease of use.
+
 mod config;
 mod option;
 
@@ -7,6 +13,12 @@ use structopt::StructOpt;
 use option::CommandLineOptions;
 use option::Options;
 
+/// The entrypoint of the binary
+///
+/// As is standard practice in Rust, most of the work is done by internal
+/// libraries, and this function simply calls into those libraries.
+/// Specifically, it parses the command line arguments and calls the kernel with
+/// them, printing out errors if there were any.
 fn main() -> Result<(), Box<dyn Error>> {
     Options::parse_options_like(CommandLineOptions::from_args())?.execute()?;
     Ok(())

--- a/src/bin/sus/main.rs
+++ b/src/bin/sus/main.rs
@@ -1,3 +1,9 @@
+mod option;
+
+use option::CommandLineOptions;
+use structopt::StructOpt;
+
 fn main() {
-    println!("Hello world!");
+    let command_line_opts = CommandLineOptions::from_args();
+    println!("{:?}", command_line_opts);
 }

--- a/src/bin/sus/main.rs
+++ b/src/bin/sus/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod option;
 
 use std::error::Error;

--- a/src/bin/sus/main.rs
+++ b/src/bin/sus/main.rs
@@ -1,9 +1,11 @@
 mod option;
 
 use option::CommandLineOptions;
+use option::Options;
 use structopt::StructOpt;
 
 fn main() {
     let command_line_opts = CommandLineOptions::from_args();
-    println!("{:?}", command_line_opts);
+    let opts = Options::parse_options_like(command_line_opts);
+    println!("{:?}", opts);
 }

--- a/src/bin/sus/main.rs
+++ b/src/bin/sus/main.rs
@@ -8,9 +8,6 @@ use option::CommandLineOptions;
 use option::Options;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let command_line_opts = CommandLineOptions::from_args();
-    let opts = Options::parse_options_like(command_line_opts)?;
-    println!("{:?}", opts.to_kernel_commandline()?);
-
+    Options::parse_options_like(CommandLineOptions::from_args())?.execute()?;
     Ok(())
 }

--- a/src/bin/sus/main.rs
+++ b/src/bin/sus/main.rs
@@ -7,7 +7,7 @@
 mod config;
 mod option;
 
-use std::error::Error;
+use std::process::exit;
 use structopt::StructOpt;
 
 use option::CommandLineOptions;
@@ -19,7 +19,25 @@ use option::Options;
 /// libraries, and this function simply calls into those libraries.
 /// Specifically, it parses the command line arguments and calls the kernel with
 /// them, printing out errors if there were any.
-fn main() -> Result<(), Box<dyn Error>> {
-    Options::parse_options_like(CommandLineOptions::from_args())?.execute()?;
-    Ok(())
+///
+/// In this function, we need to manually pretty-print errors.
+fn main() {
+    // Create the options and check for errors
+    let opts = match Options::parse_options_like(CommandLineOptions::from_args()) {
+        Err(e) => {
+            println!("Error: {}", e);
+            exit(101);
+        }
+        Ok(o) => o,
+    };
+    // Execute and print any errors
+    let res = opts.execute();
+    if let Err(e) = res {
+        println!("Error: {}", e);
+        exit(101);
+    }
+
+    // We should never be able to reach here
+    // The execution should happen before
+    println!("Successfully failed");
 }

--- a/src/bin/sus/option/commandline.rs
+++ b/src/bin/sus/option/commandline.rs
@@ -96,7 +96,7 @@ impl OptionsLike for CommandLineOptions {
 
     /// Function to get the Primary GID
     ///
-    /// Very similar to [uid], with much the same semantics. Allows the user to
+    /// Very similar to [Uid], with much the same semantics. Allows the user to
     /// set the primary group to execute as.
     fn primary_gid(&self) -> Result<Gid, OptionsError> {
         // Root if not provided

--- a/src/bin/sus/option/commandline.rs
+++ b/src/bin/sus/option/commandline.rs
@@ -1,0 +1,44 @@
+//! Parse command line options from the user
+//!
+//! This structure defines an [CommandLineOptions] struct, which is populated
+//! from the command line using the `structopt` library. This can then be
+//! converted to a list of arguments to pass to the kernel via `exec`.
+
+use std::ffi::CString;
+use structopt::StructOpt;
+
+/// The `sus` interface
+///
+/// The options here are used by the `sus` binary to interface with the
+/// `sus-kernel`. It's modeled after `sudo`. However, some options have been
+/// stripped away because the kernel can't support them.
+#[derive(Debug, StructOpt)]
+#[structopt(name = "sus")]
+pub struct CommandLineOptions {
+    /// The User to run as
+    #[structopt(short = "u")]
+    user: Option<String>,
+
+    /// The Primary Group to run as
+    #[structopt(short = "g")]
+    primary_group: Option<String>,
+
+    /// Preserve the Secondary Groups vector
+    #[structopt(short = "P")]
+    preserve_secondary_groups: bool,
+
+    /// Whether to just run the shell
+    #[structopt(short = "s")]
+    shell: bool,
+    /// Whether to run the shell as login
+    #[structopt(short = "i")]
+    shell_login: bool,
+
+    /// Run the given command in the background
+    #[structopt(short = "b")]
+    background: bool,
+
+    /// The command to execute
+    #[structopt(parse(try_from_str = CString::new))]
+    command: Vec<CString>,
+}

--- a/src/bin/sus/option/commandline.rs
+++ b/src/bin/sus/option/commandline.rs
@@ -229,18 +229,20 @@ impl OptionsLike for CommandLineOptions {
             ret.push(CString::new("-l").map_err(|_| OptionsError::BadParse { string: None })?);
         }
 
-        // Execute a particular command
-        ret.push(CString::new("-c").map_err(|_| OptionsError::BadParse { string: None })?);
-        ret.push(
-            CString::new(
-                self.command
-                    .iter()
-                    .map(|s| s.as_bytes())
-                    .collect::<Vec<&[u8]>>()
-                    .join(&0x20),
-            )
-            .map_err(|_| OptionsError::BadParse { string: None })?,
-        );
+        // Execute a particular command if we're not just executing a shell
+        if !self.command.is_empty() {
+            ret.push(CString::new("-c").map_err(|_| OptionsError::BadParse { string: None })?);
+            ret.push(
+                CString::new(
+                    self.command
+                        .iter()
+                        .map(|s| s.as_bytes())
+                        .collect::<Vec<&[u8]>>()
+                        .join(&0x20),
+                )
+                .map_err(|_| OptionsError::BadParse { string: None })?,
+            );
+        }
 
         Ok(ret)
     }

--- a/src/bin/sus/option/commandline.rs
+++ b/src/bin/sus/option/commandline.rs
@@ -146,7 +146,7 @@ impl OptionsLike for CommandLineOptions {
         if self.preserve_secondary_groups {
             return match unistd::getgroups() {
                 Err(n) => Err(OptionsError::SyscallFailure {
-                    syscall_name: Some("getgroups"),
+                    name: Some("getgroups"),
                     err: Some(n),
                 }),
                 Ok(v) => Ok(v.into_iter().collect()),

--- a/src/bin/sus/option/commandline.rs
+++ b/src/bin/sus/option/commandline.rs
@@ -158,7 +158,16 @@ impl OptionsLike for CommandLineOptions {
         let gid = self.primary_gid()?.as_raw();
         match users::get_user_groups(uname, gid) {
             None => Err(OptionsError::GroupNotFound { name: None }),
-            Some(v) => Ok(v.into_iter().map(|g| Gid::from_raw(g.gid())).collect()),
+            Some(v) => {
+                // Collect the results
+                let mut gids: HashSet<Gid> =
+                    v.into_iter().map(|g| Gid::from_raw(g.gid())).collect();
+                // Remove root
+                // No idea why it's being returned
+                gids.remove(&Gid::from_raw(0));
+                // Return
+                Ok(gids)
+            }
         }
     }
 

--- a/src/bin/sus/option/commandline.rs
+++ b/src/bin/sus/option/commandline.rs
@@ -7,6 +7,8 @@
 use std::collections::HashSet;
 use std::ffi::CString;
 use std::os::unix::ffi::OsStringExt;
+
+use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
 use nix::libc::{gid_t, uid_t};
@@ -23,8 +25,13 @@ use super::OptionsLike;
 /// The options here are used by the `sus` binary to interface with the
 /// `sus-kernel`. It's modeled after `sudo`. However, some options have been
 /// stripped away because the kernel can't support them.
+// We have to convince `clap` to not put the version. See:
+// <https://github.com/TeXitoi/structopt/issues/81
 #[derive(Debug, StructOpt)]
-#[structopt(name = "sus")]
+#[structopt(
+    name = "sus",
+    global_settings = &[AppSettings::DisableVersion]
+)]
 pub struct CommandLineOptions {
     /// The User to run as
     #[structopt(short = "u")]

--- a/src/bin/sus/option/commandline.rs
+++ b/src/bin/sus/option/commandline.rs
@@ -52,10 +52,6 @@ pub struct CommandLineOptions {
     #[structopt(short = "i")]
     shell_login: bool,
 
-    /// Run the given command in the background
-    #[structopt(short = "b")]
-    background: bool,
-
     /// The binary to execute and the arguments to give it
     #[structopt(parse(try_from_str = CString::new))]
     command: Vec<CString>,

--- a/src/bin/sus/option/commandline.rs
+++ b/src/bin/sus/option/commandline.rs
@@ -4,8 +4,19 @@
 //! from the command line using the `structopt` library. This can then be
 //! converted to a list of arguments to pass to the kernel via `exec`.
 
+use std::collections::HashSet;
 use std::ffi::CString;
+use std::os::unix::ffi::OsStringExt;
 use structopt::StructOpt;
+
+use nix::libc::{gid_t, uid_t};
+use nix::unistd;
+use nix::unistd::{Gid, Uid};
+use users;
+use which;
+
+use super::OptionsError;
+use super::OptionsLike;
 
 /// The `sus` interface
 ///
@@ -38,7 +49,190 @@ pub struct CommandLineOptions {
     #[structopt(short = "b")]
     background: bool,
 
-    /// The command to execute
+    /// The binary to execute and the arguments to give it
     #[structopt(parse(try_from_str = CString::new))]
     command: Vec<CString>,
+}
+
+impl OptionsLike for CommandLineOptions {
+    /// Function to get the UID from the user's name
+    ///
+    /// This function parses the name the user gives. If they don't give
+    /// anything, the default is root. Otherwise, if the user prefixes the name
+    /// with a `#`, it's interpreted as a number. Otherwise, we look up the
+    /// name.
+    fn uid(&self) -> Result<Uid, OptionsError> {
+        // Root if not provided
+        // Otherwise, extract a &str
+        let user_req = match &self.user {
+            None => {
+                return Ok(Uid::from_raw(0));
+            }
+            Some(u) => u,
+        };
+
+        // If the string starts with `#`, parse the number
+        match user_req.strip_prefix('#') {
+            None => {}
+            Some(id_str) => {
+                // Parse to an integer and return failure if can't
+                return match id_str.parse::<uid_t>() {
+                    Err(_) => Err(OptionsError::BadParse {
+                        string: Some(id_str.to_string()),
+                    }),
+                    Ok(id) => Ok(Uid::from_raw(id)),
+                };
+            }
+        };
+
+        // Otherwise, look up
+        match users::get_user_by_name(user_req) {
+            None => Err(OptionsError::UserNotFound {
+                name: Some(user_req.to_string()),
+            }),
+            Some(u) => Ok(Uid::from_raw(u.uid())),
+        }
+    }
+
+    /// Function to get the Primary GID
+    ///
+    /// Very similar to [uid], with much the same semantics. Allows the user to
+    /// set the primary group to execute as.
+    fn primary_gid(&self) -> Result<Gid, OptionsError> {
+        // Root if not provided
+        // Otherwise, extract a &str
+        let group_req = match &self.primary_group {
+            None => {
+                return Ok(Gid::from_raw(0));
+            }
+            Some(u) => u,
+        };
+
+        // If the string starts with `#`, parse the number
+        match group_req.strip_prefix('#') {
+            None => {}
+            Some(gid_str) => {
+                // Parse to an integer and return failure if can't
+                return match gid_str.parse::<gid_t>() {
+                    Err(_) => Err(OptionsError::BadParse {
+                        string: Some(gid_str.to_string()),
+                    }),
+                    Ok(gid) => Ok(Gid::from_raw(gid)),
+                };
+            }
+        };
+
+        // Otherwise look up
+        match users::get_group_by_name(group_req) {
+            None => Err(OptionsError::GroupNotFound {
+                name: Some(group_req.to_string()),
+            }),
+            Some(g) => Ok(Gid::from_raw(g.gid())),
+        }
+    }
+
+    /// Function to get the Secondary GIDs
+    ///
+    /// These parameters aren't given explicitly. Instead, the user supplies the
+    /// UID they want to run as. If they don't preserve their current groups,
+    /// they run as the groups of the target user.
+    ///
+    /// If the user does not provide a name for the user,
+    fn secondary_gids(&self) -> Result<HashSet<Gid>, OptionsError> {
+        // If we need to preserve GIDs, do that
+        if self.preserve_secondary_groups {
+            return match unistd::getgroups() {
+                Err(n) => Err(OptionsError::SyscallFailure {
+                    syscall_name: Some("getgroups"),
+                    err: Some(n),
+                }),
+                Ok(v) => Ok(v.into_iter().collect()),
+            };
+        }
+
+        // Otherwise, get the groups of the target user
+        let uname = match &self.user {
+            Some(u) => u,
+            None => "root",
+        };
+        let gid = self.primary_gid()?.as_raw();
+        match users::get_user_groups(uname, gid) {
+            None => Err(OptionsError::GroupNotFound { name: None }),
+            Some(v) => Ok(v.into_iter().map(|g| Gid::from_raw(g.gid())).collect()),
+        }
+    }
+
+    /// Function to ge the path to the binary to run
+    ///
+    /// The user only enters the name of the binary, so we have to look through
+    /// the `PATH` environment variable. If we can't find it, we error out.
+    ///
+    /// Additionally, if the user wants to run in a shell, we honor that by
+    /// returning "/bin/sh".
+    fn binary(&self) -> Result<CString, OptionsError> {
+        // If the user wants to run a shell, give a hard-coded result
+        if self.shell || self.shell_login {
+            return CString::new("/bin/sh").map_err(|_| OptionsError::BadParse { string: None });
+        }
+
+        // Parse the command to a &str
+        let cmd = match self.command.get(0) {
+            None => {
+                return Err(OptionsError::BinaryNotFound {
+                    name: Some("Not supplied".to_string()),
+                })
+            }
+            Some(c) => match c.to_str() {
+                Err(_) => return Err(OptionsError::BadParse { string: None }),
+                Ok(s) => s,
+            },
+        };
+
+        // Try to find it
+        match which::which(cmd) {
+            Err(_) => Err(OptionsError::BinaryNotFound {
+                name: Some(cmd.to_string()),
+            }),
+            Ok(p) => CString::new(p.into_os_string().into_vec())
+                .map_err(|_| OptionsError::BadParse { string: None }),
+        }
+    }
+
+    /// Function to get the arguments to the binary
+    ///
+    /// This function returns the arguments to pass to the binary, including
+    /// argument zero. If the user doesn't want a shell, this essentially passes
+    /// the arguments the user gave. If they do, it concatenates all of them
+    /// together with spaces.
+    fn args(&self) -> Result<Vec<CString>, OptionsError> {
+        // Handle the easier case
+        if !self.shell && !self.shell_login {
+            return Ok(self.command.clone());
+        }
+
+        // Create the return vector
+        // Push the shell binary, failing if conversion fails
+        let mut ret =
+            vec![CString::new("/bin/sh").map_err(|_| OptionsError::BadParse { string: None })?];
+
+        // Run as login if needed, failing if the conversion fails
+        if self.shell_login {
+            ret.push(CString::new("-l").map_err(|_| OptionsError::BadParse { string: None })?);
+        }
+
+        // Execute a particular command
+        ret.push(CString::new("-c").map_err(|_| OptionsError::BadParse { string: None })?);
+        ret.push(
+            CString::new(
+                self.command
+                    .iter()
+                    .map(|s| s.as_bytes())
+                    .collect::<Vec<&[u8]>>()
+                    .join(&0x20),
+            )
+            .map_err(|_| OptionsError::BadParse { string: None })?,
+        );
+
+        Ok(ret)
+    }
 }

--- a/src/bin/sus/option/mod.rs
+++ b/src/bin/sus/option/mod.rs
@@ -2,8 +2,100 @@
 //!
 //! The user can pass various [CommandLineOptions] to the `sus` binary to tell
 //! it what command to execute. These [CommandLineOptions] need to further be
-//! parsed to map it to the arguments the `sus-kernel` needs to take. This
+//! parsed to map it to the [Options] the `sus-kernel` needs to take. This
 //! module houses all of that functionality.
 
 pub mod commandline;
 pub use commandline::CommandLineOptions;
+
+use nix::errno::Errno;
+use nix::unistd::{Gid, Uid};
+use std::collections::HashSet;
+use std::ffi::CString;
+
+/// The options to pass to the `sus-kernel`
+///
+/// This structure is used internally to find out how to execute the kernel. It
+/// is created by parsing [CommandLineOptions] then converting them to this
+/// structure.
+#[derive(Debug)]
+pub struct Options {
+    /// The User to execute as
+    uid: Uid,
+    /// The Primary Group to change to
+    primary_gid: Gid,
+    /// The list of Secondary Groups to use
+    secondary_gids: HashSet<Gid>,
+
+    /// The name of the executable to run
+    binary: CString,
+    /// The arguments to pass to the executable
+    args: Vec<CString>,
+}
+
+/// Trait to define things that can be parsed into [Options]
+///
+/// It might be that the user can input data in a format that needs to be
+/// converted to an [Options] structure. For instance, command line arguments a
+/// probably not explicit in all the parameter. Thus, this trait allows
+/// different methods of collecting parameters from a user and merging them into
+/// a common iterface.
+pub trait OptionsLike {
+    /// Function to get the UID
+    fn uid(&self) -> Result<Uid, OptionsError>;
+    /// Function to get the Primary GID
+    fn primary_gid(&self) -> Result<Gid, OptionsError>;
+    /// Function to get the Secondary GIDs
+    fn secondary_gids(&self) -> Result<HashSet<Gid>, OptionsError>;
+    /// Function to ge the path to the binary to run
+    fn binary(&self) -> Result<CString, OptionsError>;
+    /// Function to get the arguments to the binary
+    fn args(&self) -> Result<Vec<CString>, OptionsError>;
+}
+
+/// Type for reporting errors when working with [Options]
+///
+/// Things to generate [Options] may fail. For instance, even though the user
+/// enters some arguments successfully at the command line, they may still be
+/// invalid. For example, they may not input a number where one is required, or
+/// they may provide the name of a nonexisting group. This enumeration handles
+/// those failure cases.
+#[derive(Debug)]
+pub enum OptionsError {
+    /// Could not parse something
+    BadParse { string: Option<String> },
+
+    /// User does not exist
+    UserNotFound { name: Option<String> },
+    /// Group does not exist
+    GroupNotFound { name: Option<String> },
+
+    /// Binary was not found
+    BinaryNotFound { name: Option<String> },
+
+    /// Generic failure of a system call
+    SyscallFailure {
+        syscall_name: Option<&'static str>,
+        err: Option<Errno>,
+    },
+}
+
+impl Options {
+    /// Create an [Options] from an [OptionsLike]
+    ///
+    /// `TryFrom` would be better here, but we can't use that with generics.
+    /// See: https://github.com/rust-lang/rust/issues/50133
+    pub fn parse_options_like<T>(ol: T) -> Result<Options, OptionsError>
+    where
+        T: OptionsLike,
+    {
+        // Return the results of the function calls
+        Ok(Options {
+            uid: ol.uid()?,
+            primary_gid: ol.primary_gid()?,
+            secondary_gids: ol.secondary_gids()?,
+            binary: ol.binary()?,
+            args: ol.args()?,
+        })
+    }
+}

--- a/src/bin/sus/option/mod.rs
+++ b/src/bin/sus/option/mod.rs
@@ -1,0 +1,9 @@
+//! Module for handling the options the user passes
+//!
+//! The user can pass various [CommandLineOptions] to the `sus` binary to tell
+//! it what command to execute. These [CommandLineOptions] need to further be
+//! parsed to map it to the arguments the `sus-kernel` needs to take. This
+//! module houses all of that functionality.
+
+pub mod commandline;
+pub use commandline::CommandLineOptions;


### PR DESCRIPTION
Ideally, the user would not have to invoke the sus kernel directly. Instead, they would do so through a userspace program that provides a nice interface. This pull request provides a basic userspae binary that does that. The interface is the same as `sudo`, but with unsupported features stripped out.

Closes #13 